### PR TITLE
wrap, lift, and accumulate, with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoff",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A collection of higher order functions you may find useful",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.es6
+++ b/src/index.es6
@@ -1,8 +1,10 @@
 'use strict';
 
+export accumulate from './lib/accumulate';
 export compose from './lib/compose';
 export curry from './lib/curry';
 export identity from './lib/identity';
+export lift from './lib/lift';
 export not from './lib/not';
 export partial from './lib/partial';
 export partition from './lib/partition';

--- a/src/lib/accumulate.es6
+++ b/src/lib/accumulate.es6
@@ -1,0 +1,5 @@
+'use strict';
+
+const accumulate = (fn, iv) => (...args) => args.reduce(fn, iv);
+
+export default accumulate;

--- a/src/lib/lift.es6
+++ b/src/lib/lift.es6
@@ -1,0 +1,7 @@
+'use strict';
+
+import identity from './identity';
+
+const lift = (fn, lifter = identity) => (...args) => fn(...args.map(lifter));
+
+export default lift;

--- a/src/lib/unwrap.es6
+++ b/src/lib/unwrap.es6
@@ -1,5 +1,6 @@
 'use strict';
-
+// return first element of an array
+// without any array packing
 const unwrap = ([first,]) => first;
 
 export default unwrap;

--- a/src/lib/wrap.es6
+++ b/src/lib/wrap.es6
@@ -1,0 +1,5 @@
+'use strict';
+
+const wrap = (fn, n) => fn(n);
+
+export default wrap;

--- a/src/test/_integration.es6
+++ b/src/test/_integration.es6
@@ -1,0 +1,21 @@
+'use strict';
+
+import test from 'tape';
+import * as hoff from '../index';
+import {add} from './util/simpleFunctions';
+
+test('Integration test', (t) => {
+
+	t.test('Lift and accumulate', (t) => {
+		t.plan(3);
+		const numbers = ['1', '2', '3', '4'],
+			liftAcc = hoff.lift(hoff.accumulate(add, 0), Number),
+			accLift = hoff.accumulate(hoff.lift(add, Number), 0),
+			result1 = liftAcc(...numbers),
+			result2 = accLift(...numbers);
+		t.is(typeof liftAcc, 'function', 'Lift and accumulate composed together');
+		t.is(result1, 10, 'Computed correctly with proper types.');
+		t.is(result1, result2, 'Composition order does not matter');
+	});
+	
+});

--- a/src/test/accumulate.es6
+++ b/src/test/accumulate.es6
@@ -1,0 +1,17 @@
+'use strict';
+
+import test from 'tape';
+import accumulate from '../lib/accumulate';
+import {add, mult} from './util/simpleFunctions';
+
+test('Accumulate test', (t) => {
+	t.plan(3);
+	const numbers = [1, 2, 3, 4, 5],
+		sum = accumulate(add, 0),
+		multiply = accumulate(mult, 1),
+		result = sum(...numbers),
+		remult = multiply(...numbers);
+	t.is(typeof sum, 'function', 'Converts to function');
+	t.is(result, 15, 'Accumulates add() correctly');
+	t.is(remult, 120, 'Accumulates mult() correctly');
+});

--- a/src/test/lift.es6
+++ b/src/test/lift.es6
@@ -1,0 +1,15 @@
+'use strict';
+
+import test from 'tape';
+import lift from '../lib/lift';
+import {add} from './util/simpleFunctions';
+
+test('Lift test', (t) => {
+	t.plan(2);
+	const a = '3', 
+		b = '4', 
+		ensureNumericAdd = lift(add, Number),
+		result = ensureNumericAdd(a, b);
+	t.is(add(a, b), '34', 'Converted inappropriately at first');
+	t.is(result, 7, 'Converts appropriately after lift');
+});

--- a/src/test/util/simpleFunctions.es6
+++ b/src/test/util/simpleFunctions.es6
@@ -5,3 +5,5 @@ export const dub = (a) => a * 2;
 export const sq = Math.sqrt;
 export const exp = Math.pow;
 export const mult = (a, b) => a * b;
+export const recurAdd = (...args) => args.slice(1).reduce(add, args[0]);
+export const recurMult = (...args) => args.slice(1).reduce(mult, args[0]);

--- a/src/test/wrap.es6
+++ b/src/test/wrap.es6
@@ -1,0 +1,21 @@
+'use strict';
+
+import test from 'tape';
+import wrap from '../lib/wrap';
+import partial from '../lib/partial';
+import {add} from './util/simpleFunctions';
+
+test('Wrap test', (t) => {
+  t.plan(3);
+
+  const a = '3',
+    b = '4',
+    addStrings = add(a,b),
+    numify = partial(wrap, Number),
+    addNums = add(numify(a), numify(b));
+
+  t.is(addStrings, '34', 'strings were added');
+  t.is(numify(a), 3, 'wrap converted to Number');
+  t.is(addNums, 7, 'conversion was successful');
+
+});


### PR DESCRIPTION
v1.2.0
- `lift` - runs your function with a wrapper function applied to all arguments
- `accumulate` - turns a binary function into an accumulator, where `add, [a,b,c]` will unwrap to `(a + b) + c)`
- `wrap` - calls function `fn` on `n` and returns the value of that operation
